### PR TITLE
Create three_is_company.patch

### DIFF
--- a/plugin_template/patches/three_is_company.patch
+++ b/plugin_template/patches/three_is_company.patch
@@ -1,0 +1,3 @@
+:missions #KSP2Mission_Secondary_Ike_LandingCrewed > missionStages > _0 > ConditionSet > PropertyCondition {
+  RequireCurrentValue: true;
+}


### PR DESCRIPTION
Should fix incorrect completion conditions on "Three is company"
Can't test atm but should be able to test by giving yourself the mission with
```scss
:missions #KSP2Mission_Secondary_Ike_LandingCrewed {
  state: Active;
}
```