### PR TITLE
Fix for date-time's in the save/load menu not respecting machine culture 

### DIFF
--- a/src/CommunityFixes/Fix/SaveLoadDateTimeFix/SaveLoadDateTimeFix.cs
+++ b/src/CommunityFixes/Fix/SaveLoadDateTimeFix/SaveLoadDateTimeFix.cs
@@ -1,0 +1,10 @@
+﻿namespace CommunityFixes.Fix.STFUFix;
+
+[Fix("Save/Load Date/Time Fix")]
+public class SaveLoadDateTimeFix : BaseFix
+{
+    public override void OnInitialized()
+    {
+        HarmonyInstance.PatchAll(typeof(SaveLoadDateTimeFix_Patch));
+    }
+}

--- a/src/CommunityFixes/Fix/SaveLoadDateTimeFix/SaveLoadDateTimeFix_Patch.cs
+++ b/src/CommunityFixes/Fix/SaveLoadDateTimeFix/SaveLoadDateTimeFix_Patch.cs
@@ -1,0 +1,37 @@
+﻿using HarmonyLib;
+using KSP.Game;
+using System.Globalization;
+using UnityEngine.UI;
+
+namespace CommunityFixes.Fix.STFUFix;
+
+internal class SaveLoadDateTimeFix_Patch
+{
+    [HarmonyPatch(typeof(SaveLoadDialogFileEntry), nameof(SaveLoadDialogFileEntry.Initialize), new Type[] { typeof(ExtendedSaveFileInfo), typeof(bool), typeof(bool) })]
+    [HarmonyPrefix]
+    public static void SaveLoadDialogFileEntry_Initialize(SaveLoadDialogFileEntry __instance, ExtendedSaveFileInfo fileInfo, bool loading, bool isLastPlayed)
+    {
+        CultureInfo.DefaultThreadCurrentCulture = Thread.CurrentThread.CurrentUICulture;
+    }
+
+    [HarmonyPatch(typeof(SaveLoadDialog), nameof(SaveLoadDialog.UpdateLoadMenuGameInformation), new Type[] { typeof(ExtendedSaveFileInfo), typeof(Image) })]
+    [HarmonyPrefix]
+    public static void SaveLoadDialog_UpdateLoadMenuGameInformation(SaveLoadDialog __instance, ExtendedSaveFileInfo fileInfo, Image thumnailScreenshot)
+    {
+        CultureInfo.DefaultThreadCurrentCulture = Thread.CurrentThread.CurrentUICulture;
+    }
+
+    [HarmonyPatch(typeof(CampaignLoadMenu), nameof(CampaignLoadMenu.UpdateLoadMenuGameInformation), new Type[] { typeof(ExtendedSaveFileInfo), typeof(Image) })]
+    [HarmonyPrefix]
+    public static void CampaignLoadMenu_UpdateLoadMenuGameInformation(CampaignLoadMenu __instance, ExtendedSaveFileInfo fileInfo, Image thumnailScreenshot)
+    {
+        CultureInfo.DefaultThreadCurrentCulture = Thread.CurrentThread.CurrentUICulture;
+    }
+
+    [HarmonyPatch(typeof(CampaignTileEntry), nameof(CampaignTileEntry.Initialize), new Type[] { typeof(ExtendedSaveFileInfo), typeof(CampaignLoadMenu), typeof(CampaignMenu) })]
+    [HarmonyPrefix]
+    public static void CampaignTileEntry_UpdateLoadMenuGameInformation(CampaignTileEntry __instance, ExtendedSaveFileInfo fileInfo, CampaignLoadMenu loadMenu, CampaignMenu campaignMenu)
+    {
+        CultureInfo.DefaultThreadCurrentCulture = Thread.CurrentThread.CurrentUICulture;
+    }
+}


### PR DESCRIPTION
All date/times in the save/load menu fell back to US format mm/dd/yyyy, rather than respecting the UI culture.

This was down to the thread culture not being set, even though the UI culture was set. and DateTime.ToString respects the thread culture rather than the UI culture.

This patch forces the thread culture to be set correctly where needed